### PR TITLE
支持唯一标识符算子的表结构推断

### DIFF
--- a/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifier.scala
+++ b/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifier.scala
@@ -1,9 +1,11 @@
 package tech.mlsql.plugins.mllib.ets.fe
 
+import com.google.gson.{JsonObject, JsonParser}
 import org.apache.spark.ZippedWithGivenIndexRDD
 import org.apache.spark.ml.param.Param
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.types.{LongType, StructField, StructType}
+import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import streaming.dsl.ScriptSQLExec
 import streaming.dsl.auth._
@@ -15,6 +17,8 @@ import tech.mlsql.dsl.auth.ETAuth
 import tech.mlsql.dsl.auth.dsl.mmlib.ETMethod.ETMethod
 
 import scala.annotation.tailrec
+import scala.collection.JavaConversions.asScalaSet
+import scala.collection.mutable
 
 /**
  * 27/07/2022 hellozepp(lisheng.zhanglin@163.com)
@@ -34,12 +38,12 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
       extra = Extra(
         doc =
           s"""
-            | unique source
-            | When the value is `new`, the behavior is to create a new column, and you need to specify the column name of the new column, the default is `$DEFAULT_COLUMN_NAME`.
-            | When the value is `replace`, the behavior is to replace the existing column.
-            |  > Note that if a new column is created with a column name that conflicts with an existing column name, an
-            |  > error message should be reported
-            | e.g. source = "new"
+             | unique source
+             | When the value is `new`, the behavior is to create a new column, and you need to specify the column name of the new column, the default is `$DEFAULT_COLUMN_NAME`.
+             | When the value is `replace`, the behavior is to replace the existing column.
+             |  > Note that if a new column is created with a column name that conflicts with an existing column name, an
+             |  > error message should be reported
+             | e.g. source = "new"
           """,
         label = "action for syntax analysis",
         options = Map(
@@ -78,10 +82,39 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
   )
   setDefault(columnName, DEFAULT_COLUMN_NAME)
 
+  final val INFER_MODE = "inferSchema"
+  final val DATA_MODE = "data"
+  final val mode: Param[String] = new Param[String](this, "mode",
+    FormParams.toJson(Select(
+      name = "mode",
+      values = List(),
+      extra = Extra(
+        doc =
+          """
+            | Get output table structure and type by inference.
+            | e.g. mode = "inferSchema"
+          """,
+        label = "mode",
+        options = Map(
+          "valueType" -> "string",
+          "defaultValue" -> DATA_MODE,
+          "required" -> "false",
+          "derivedType" -> "NONE"
+        )), valueProvider = Option(() => {
+        List(KV(Option("mode"), Option(INFER_MODE)),
+          KV(Option("mode"), Option(DATA_MODE))
+        )
+      })
+    )
+    )
+  )
+  setDefault(mode, DATA_MODE)
+
   def this() = this(BaseParams.randomUID())
 
   override def codeExample: Code = Code(SQLCode,
     """
+      |You can use the run/train syntax to execute UniqueIdentifier to generate a column with unique values. The example is as follows:
       |
       |set abc='''
       |{"name": "elena", "age": 57, "phone": 15552231521, "income": 433000, "label": 0}
@@ -95,6 +128,23 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
       |load jsonStr.`abc` as table1;
       |select age, income from table1 as table2;
       |run table2 as UniqueIdentifier.`` where source="replace" and columnName="income" as uniqueIdentifier;
+      |
+      |You can also use the infer schema feature to infer its resulting table structure without performing ET, as an example:
+      |
+      |set abc='''
+      |{"name": "elena", "age": 57, "phone": 15552231521, "income": 433000, "label": 0}
+      |{"name": "candy", "age": 67, "phone": 15552231521, "income": 1200, "label": 0}
+      |{"name": "bob", "age": 57, "phone": 15252211521, "income": 89000, "label": 0}
+      |{"name": "candy", "age": 25, "phone": 15552211522, "income": 36000, "label": 1}
+      |{"name": "candy", "age": 31, "phone": 15552211521, "income": 300000, "label": 1}
+      |{"name": "finn", "age": 23, "phone": 15552211521, "income": 238000, "label": 1}
+      |''';
+      |
+      |load jsonStr.`abc` as table1;
+      |select age, income from table1 as table2;
+      |-- !desc  table2;
+      |run table2 as UniqueIdentifier.`` where source="new" and columnName="income1" and mode="inferSchema" and inputSchema='''{"age":"bigint", "income":"bigint"}''' as uniqueIdentifier;
+      |
       |;
     """.stripMargin)
 
@@ -115,13 +165,29 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
     }
   }
 
+  override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
+    throw new RuntimeException(s"${getClass.getName} not support load function.")
+  }
+
+  override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = {
+    throw new RuntimeException(s"${getClass.getName} not support predict function.")
+  }
+
+  override def batchPredict(df: DataFrame, path: String, params: Map[String, String]): DataFrame =
+    train(df, path, params)
+
   override def train(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
 
-    var sourceCol = String.valueOf(params.getOrElse(source.name, SOURCE_MODE_NEW)).toLowerCase()
-    val columnNameCol = String.valueOf(params.getOrElse(columnName.name, DEFAULT_COLUMN_NAME))
-    if (!sourceOptionalVal.contains(KV(Option(source.name), Option(sourceCol)))) {
-      throw new IllegalArgumentException(s"Illegal source parameter: $sourceCol")
+    var sourceCol = params.getOrElse(source.name, SOURCE_MODE_NEW).toLowerCase()
+    val columnNameCol = params.getOrElse(columnName.name, DEFAULT_COLUMN_NAME)
+    val curMode = params.getOrElse(mode.name, if (params.getOrElse("onlyInferSchema", "false").toBoolean) INFER_MODE else DATA_MODE)
+    val onlyInferSchema = if (INFER_MODE.equals(curMode)) true else false
+
+    if (onlyInferSchema) {
+      return inferSchema(df, path, params)
     }
+
+    verifyParams(sourceCol)
 
     val fieldNames = df.schema.map(sc => {
       sc.name
@@ -164,14 +230,54 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
     getRowRDD
   }
 
-  override def load(sparkSession: SparkSession, path: String, params: Map[String, String]): Any = {
-    throw new RuntimeException(s"${getClass.getName} not support load function.")
+  def inferSchema(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
+    var sourceCol = String.valueOf(params.getOrElse(source.name, SOURCE_MODE_NEW)).toLowerCase()
+    val columnNameCol = String.valueOf(params.getOrElse(columnName.name, DEFAULT_COLUMN_NAME))
+    val jsonParser = new JsonParser()
+    val inputSchemaStr = String.valueOf(params.getOrElse("inputSchema", "{}"))
+    val jsonObj = jsonParser.parse(inputSchemaStr).asInstanceOf[JsonObject]
+    val inputSchema = mutable.LinkedHashMap[String, String]()
+    for (i <- jsonObj.entrySet) if (i != null && i.getKey != null) {
+      inputSchema.put(i.getKey, if (i.getValue != null) i.getValue.getAsString else null)
+    }
+
+    verifyParams(sourceCol)
+
+    val spark = df.sparkSession
+
+    @tailrec
+    def getRowRDD: DataFrame = sourceCol match {
+      case SOURCE_MODE_NEW =>
+        spark.createDataFrame(hashMap2RDD(mutable.LinkedHashMap[String, String](columnNameCol -> "bigint") ++: inputSchema, spark),
+          StructType(Seq(StructField("col_name", StringType, nullable = false), StructField("data_type", StringType, nullable = false))))
+      case SOURCE_MODE_REPLACE =>
+        val fieldNames = df.schema.map(sc => {
+          sc.name
+        }).toSet
+        if (!fieldNames.contains(columnNameCol)) {
+          sourceCol = SOURCE_MODE_NEW
+          getRowRDD
+        } else {
+          spark.createDataFrame(hashMap2RDD(inputSchema, spark),
+            StructType(Seq(StructField("col_name", StringType, nullable = false),
+              StructField("data_type", StringType, nullable = false)
+            )))
+        }
+    }
+    getRowRDD
   }
 
-  override def predict(sparkSession: SparkSession, _model: Any, name: String, params: Map[String, String]): UserDefinedFunction = {
-    throw new RuntimeException(s"${getClass.getName} not support predict function.")
+  def verifyParams(sourceCol: String): Unit = {
+    if (!sourceOptionalVal.contains(KV(Option(source.name), Option(sourceCol)))) {
+      throw new IllegalArgumentException(s"Illegal source parameter: $sourceCol")
+    }
   }
 
-  override def batchPredict(df: DataFrame, path: String, params: Map[String, String]): DataFrame =
-    train(df, path, params)
+  private def hashMap2RDD(map: mutable.Map[String, String], spark: SparkSession): RDD[Row] = {
+    var demoSeq: Seq[Row] = Seq.empty
+    map.foreach(mainKey => {
+      demoSeq ++= Seq(Row.fromSeq(Seq(mainKey._1, mainKey._2)))
+    })
+    spark.sparkContext.parallelize(demoSeq)
+  }
 }


### PR DESCRIPTION
You can also use the infer schema feature to infer its resulting table structure without performing ET, as an example:
```
set abc='''
{"name": "elena", "age": 57, "phone": 15552231521, "income": 433000, "label": 0}
{"name": "candy", "age": 67, "phone": 15552231521, "income": 1200, "label": 0}
{"name": "bob", "age": 57, "phone": 15252211521, "income": 89000, "label": 0}
{"name": "candy", "age": 25, "phone": 15552211522, "income": 36000, "label": 1}
{"name": "candy", "age": 31, "phone": 15552211521, "income": 300000, "label": 1}
{"name": "finn", "age": 23, "phone": 15552211521, "income": 238000, "label": 1}
''';

load jsonStr.`abc` as table1;
select age, income from table1 as table2;
-- !desc  table2;
run table2 as UniqueIdentifier.`` where source="new" and columnName="income1" and onlyInferSchema="true" and inputSchema='''{"age":"bigint", "income":"bigint"}''' as uniqueIdentifier;
  ```