### PR TITLE
【唯一标识符算子】算子index错误以及替换列导致异常bugfix

### DIFF
--- a/mlsql-mllib/src/main/java/org/apache/spark/ZippedWithGivenIndexRDD.scala
+++ b/mlsql-mllib/src/main/java/org/apache/spark/ZippedWithGivenIndexRDD.scala
@@ -21,13 +21,14 @@ class ZippedWithGivenIndexRDD[T: ClassTag](prev: RDD[T], startIndex: Long = 0) e
     if (n == 0) {
       Array.empty
     } else if (n == 1) {
-      Array(0L)
+      Array(startIndex)
     } else {
-      prev.context.runJob(
+      val longs = prev.context.runJob(
         prev,
         Utils.getIteratorSize _,
         0 until n - 1 // do not need to count the last partition
       ).scanLeft(startIndex)(_ + _)
+      longs
     }
   }
 

--- a/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifier.scala
+++ b/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifier.scala
@@ -1,6 +1,7 @@
 package tech.mlsql.plugins.mllib.ets.fe
 
-import com.google.gson.{JsonObject, JsonParser}
+import com.google.gson.{JsonArray, JsonParser}
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.ZippedWithGivenIndexRDD
 import org.apache.spark.ml.param.Param
 import org.apache.spark.rdd.RDD
@@ -27,6 +28,7 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
   final val SOURCE_MODE_NEW = "new"
   final val SOURCE_MODE_REPLACE = "replace"
   final val DEFAULT_COLUMN_NAME = "Unique_ID"
+  final val DEFAULT_START_INDEX = "1"
   final val sourceOptionalVal = List(KV(Option("source"), Option(SOURCE_MODE_NEW)),
     KV(Option("source"), Option(SOURCE_MODE_REPLACE))
   )
@@ -39,7 +41,8 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
         doc =
           s"""
              | unique source
-             | When the value is `new`, the behavior is to create a new column, and you need to specify the column name of the new column, the default is `$DEFAULT_COLUMN_NAME`.
+             | When the value is `new`, the behavior is to create a new column, and you need to specify the column name
+             | of the new column, the default is `$DEFAULT_COLUMN_NAME`.
              | When the value is `replace`, the behavior is to replace the existing column.
              |  > Note that if a new column is created with a column name that conflicts with an existing column name, an
              |  > error message should be reported
@@ -82,6 +85,30 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
   )
   setDefault(columnName, DEFAULT_COLUMN_NAME)
 
+  final val startIndex: Param[String] = new Param[String](this, "startIndex",
+    FormParams.toJson(Input(
+      name = "startIndex",
+      value = "",
+      extra = Extra(
+        doc =
+          """
+            | Index of start
+            | e.g. startIndex = "1"
+          """,
+        label = "startIndex",
+        options = Map(
+          "valueType" -> "string",
+          "defaultValue" -> DEFAULT_COLUMN_NAME,
+          "required" -> "false",
+          "derivedType" -> "NONE"
+        )), valueProvider = Option(() => {
+        ""
+      })
+    )
+    )
+  )
+  setDefault(startIndex, DEFAULT_START_INDEX)
+
   final val INFER_MODE = "inferSchema"
   final val DATA_MODE = "data"
   final val mode: Param[String] = new Param[String](this, "mode",
@@ -114,36 +141,39 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
 
   override def codeExample: Code = Code(SQLCode,
     """
-      |You can use the run/train syntax to execute UniqueIdentifier to generate a column with unique values. The example is as follows:
+      | You can use the run/train syntax to execute UniqueIdentifier to generate a column with unique values. The
+      | example is as follows:
       |
-      |set abc='''
-      |{"name": "elena", "age": 57, "phone": 15552231521, "income": 433000, "label": 0}
-      |{"name": "candy", "age": 67, "phone": 15552231521, "income": 1200, "label": 0}
-      |{"name": "bob", "age": 57, "phone": 15252211521, "income": 89000, "label": 0}
-      |{"name": "candy", "age": 25, "phone": 15552211522, "income": 36000, "label": 1}
-      |{"name": "candy", "age": 31, "phone": 15552211521, "income": 300000, "label": 1}
-      |{"name": "finn", "age": 23, "phone": 15552211521, "income": 238000, "label": 1}
-      |''';
+      | set abc='''
+      | {"name": "elena", "age": 57, "phone": 15552231521, "income": 433000, "label": 0}
+      | {"name": "candy", "age": 67, "phone": 15552231521, "income": 1200, "label": 0}
+      | {"name": "bob", "age": 57, "phone": 15252211521, "income": 89000, "label": 0}
+      | {"name": "candy", "age": 25, "phone": 15552211522, "income": 36000, "label": 1}
+      | {"name": "candy", "age": 31, "phone": 15552211521, "income": 300000, "label": 1}
+      | {"name": "finn", "age": 23, "phone": 15552211521, "income": 238000, "label": 1}
+      | ''';
       |
-      |load jsonStr.`abc` as table1;
-      |select age, income from table1 as table2;
-      |run table2 as UniqueIdentifier.`` where source="replace" and columnName="income" as uniqueIdentifier;
+      | load jsonStr.`abc` as table1;
+      | select age, income from table1 as table2;
+      | run table2 as UniqueIdentifier.`` where source="replace" and columnName="income" as uniqueIdentifier;
       |
-      |You can also use the infer schema feature to infer its resulting table structure without performing ET, as an example:
+      | You can also use the infer schema feature to infer its resulting table structure without performing ET,
+      | as an example:
       |
-      |set abc='''
-      |{"name": "elena", "age": 57, "phone": 15552231521, "income": 433000, "label": 0}
-      |{"name": "candy", "age": 67, "phone": 15552231521, "income": 1200, "label": 0}
-      |{"name": "bob", "age": 57, "phone": 15252211521, "income": 89000, "label": 0}
-      |{"name": "candy", "age": 25, "phone": 15552211522, "income": 36000, "label": 1}
-      |{"name": "candy", "age": 31, "phone": 15552211521, "income": 300000, "label": 1}
-      |{"name": "finn", "age": 23, "phone": 15552211521, "income": 238000, "label": 1}
-      |''';
+      | set abc='''
+      | {"name": "elena", "age": 57, "phone": 15552231521, "income": 433000, "label": 0}
+      | {"name": "candy", "age": 67, "phone": 15552231521, "income": 1200, "label": 0}
+      | {"name": "bob", "age": 57, "phone": 15252211521, "income": 89000, "label": 0}
+      | {"name": "candy", "age": 25, "phone": 15552211522, "income": 36000, "label": 1}
+      | {"name": "candy", "age": 31, "phone": 15552211521, "income": 300000, "label": 1}
+      | {"name": "finn", "age": 23, "phone": 15552211521, "income": 238000, "label": 1}
+      | ''';
       |
-      |load jsonStr.`abc` as table1;
-      |select age, income from table1 as table2;
-      |-- !desc  table2;
-      |run table2 as UniqueIdentifier.`` where source="new" and columnName="income1" and mode="inferSchema" and inputSchema='''{"age":"bigint", "income":"bigint"}''' as uniqueIdentifier;
+      | load jsonStr.`abc` as table1;
+      | select age, income from table1 as table2;
+      | -- !desc  table2;
+      | run table2 as UniqueIdentifier.`` where source="new" and columnName="income1" and mode="inferSchema" and
+      | inputSchema='''{"age":"bigint", "income":"bigint"}''' as uniqueIdentifier;
       |
       |;
     """.stripMargin)
@@ -188,15 +218,26 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
 
   def getZippedWithIndexDF(df: DataFrame, params: Map[String, String]): DataFrame = {
     var sourceParam = params.getOrElse(source.name, SOURCE_MODE_NEW).toLowerCase()
-    val columnNameParam = params.getOrElse(columnName.name, DEFAULT_COLUMN_NAME)
+    if (sourceParam == null || sourceParam.isEmpty) {
+      sourceParam = SOURCE_MODE_NEW
+    }
     verifyParams(sourceParam)
+
+    var columnNameParam = params.getOrElse(columnName.name, DEFAULT_COLUMN_NAME)
+    if (columnNameParam == null || columnNameParam.isEmpty) {
+      columnNameParam = DEFAULT_COLUMN_NAME
+    }
+
+    var startIndexParam = params.getOrElse(startIndex.name, DEFAULT_START_INDEX)
+
+    startIndexParam = if (StringUtils.isNumeric(startIndexParam)) startIndexParam else DEFAULT_START_INDEX
 
     val fieldNames = df.schema.map(sc => {
       sc.name
     }).toSet
 
     val spark = df.sparkSession
-    val zipRdd = new ZippedWithGivenIndexRDD(df.rdd, 1)
+    val zipRdd = new ZippedWithGivenIndexRDD(df.rdd, startIndexParam.toLong)
 
     @tailrec
     def getRowRDD: DataFrame = sourceParam match {
@@ -206,7 +247,7 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
         }
 
         spark.createDataFrame(zipRdd.map { case (row, index) => Row.fromSeq(index +: row.toSeq) },
-          StructType(StructField(columnNameParam, LongType, nullable = false) +: df.schema.fields.toSeq))
+          StructType(StructField(columnNameParam, LongType, nullable = true) +: df.schema.fields.toSeq))
       case SOURCE_MODE_REPLACE =>
         /* To avoid exceptions caused by incorrect parameter settings, if the column is not present when replacing the
            schema, a new column is created. */
@@ -223,55 +264,76 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
             }
           })
           spark.createDataFrame(zipRdd.map {
+            // Modify the data in the replacement column for each row.
             case (row, index) => Row.fromSeq(row.toSeq.updated(replaceColNumber, index))
           },
-            StructType(df.schema.fields.toSeq))
+            // Modify the type of the replaced column to be the type of the unique column.
+            StructType(df.schema.fields.toSeq.updated(replaceColNumber,
+              StructField(columnNameParam, LongType, nullable = true))))
         }
     }
 
     getRowRDD
-  }
-  def inferSchema(df: DataFrame, params: Map[String, String]): DataFrame = {
-    var sourceCol = String.valueOf(params.getOrElse(source.name, SOURCE_MODE_NEW)).toLowerCase()
-    val columnNameCol = String.valueOf(params.getOrElse(columnName.name, DEFAULT_COLUMN_NAME))
-    val jsonParser = new JsonParser()
-    val inputSchemaStr = String.valueOf(params.getOrElse("inputSchema", "{}"))
-    val jsonObj = jsonParser.parse(inputSchemaStr).asInstanceOf[JsonObject]
-    val inputSchema = mutable.LinkedHashMap[String, String]()
-    for (i <- jsonObj.entrySet) if (i != null && i.getKey != null) {
-      inputSchema.put(i.getKey, if (i.getValue != null) i.getValue.getAsString else null)
-    }
-
-    verifyParams(sourceCol)
-
-    val spark = df.sparkSession
-
-    @tailrec
-    def getCurrentSchema: DataFrame = sourceCol match {
-      case SOURCE_MODE_NEW =>
-        spark.createDataFrame(hashMap2RDD(mutable.LinkedHashMap[String, String](columnNameCol -> "bigint") ++: inputSchema, spark),
-          StructType(Seq(StructField("col_name", StringType, nullable = false), StructField("data_type", StringType, nullable = false))))
-      case SOURCE_MODE_REPLACE =>
-        val fieldNames = df.schema.map(sc => {
-          sc.name
-        }).toSet
-        if (!fieldNames.contains(columnNameCol)) {
-          sourceCol = SOURCE_MODE_NEW
-          getCurrentSchema
-        } else {
-          spark.createDataFrame(hashMap2RDD(inputSchema, spark),
-            StructType(Seq(StructField("col_name", StringType, nullable = false),
-              StructField("data_type", StringType, nullable = false)
-            )))
-        }
-    }
-    getCurrentSchema
   }
 
   def verifyParams(sourceCol: String): Unit = {
     if (!sourceOptionalVal.contains(KV(Option(source.name), Option(sourceCol)))) {
       throw new IllegalArgumentException(s"Illegal source parameter: $sourceCol")
     }
+  }
+
+  def inferSchema(df: DataFrame, params: Map[String, String]): DataFrame = {
+    var sourceParam = String.valueOf(params.getOrElse(source.name, SOURCE_MODE_NEW)).toLowerCase()
+    if (sourceParam == null || sourceParam.isEmpty) {
+      sourceParam = SOURCE_MODE_NEW
+    }
+    val jsonParser = new JsonParser()
+    val inputSchemaStr = String.valueOf(params.getOrElse("inputSchema", "[]"))
+    val jsonArr = jsonParser.parse(inputSchemaStr).asInstanceOf[JsonArray]
+    val inputSchema = mutable.LinkedHashMap[String, String]()
+    for (i: Int <- 0 until jsonArr.size) {
+      val jsonObj = jsonArr.get(i).getAsJsonObject
+      var inputKey: String = null
+      var inputValue = ""
+      for (jsonPair <- jsonObj.entrySet) if (jsonPair != null && jsonPair.getKey != null) {
+        if ("col_name".equals(jsonPair.getKey)) {
+          inputKey = jsonPair.getValue.getAsString
+        } else if ("data_type".equals(jsonPair.getKey)) {
+          inputValue = if (jsonPair.getValue != null) jsonPair.getValue.getAsString else null
+        } else ()
+      }
+      if (inputKey != null) {
+        inputSchema.put(inputKey, inputValue)
+      }
+    }
+
+    verifyParams(sourceParam)
+
+    val spark = df.sparkSession
+    var columnNameParam = String.valueOf(params.getOrElse(columnName.name, DEFAULT_COLUMN_NAME))
+    if (columnNameParam == null || columnNameParam.isEmpty) {
+      columnNameParam = DEFAULT_COLUMN_NAME
+    }
+
+    @tailrec
+    def getCurrentSchema: DataFrame = sourceParam match {
+      case SOURCE_MODE_NEW =>
+        spark.createDataFrame(hashMap2RDD(mutable.LinkedHashMap[String, String](columnNameParam -> "bigint") ++: inputSchema, spark),
+          StructType(Seq(StructField("col_name", StringType, nullable = true), StructField("data_type", StringType, nullable = true))))
+      case SOURCE_MODE_REPLACE =>
+        if (!inputSchema.contains(columnNameParam)) {
+          sourceParam = SOURCE_MODE_NEW
+          getCurrentSchema
+        } else {
+          spark.createDataFrame(hashMap2RDD(inputSchema, spark),
+            StructType(Seq(StructField("col_name", StringType, nullable = true),
+              StructField("data_type", StringType, nullable = true)
+            ))
+          )
+        }
+    }
+
+    getCurrentSchema
   }
 
   private def hashMap2RDD(map: mutable.Map[String, String], spark: SparkSession): RDD[Row] = {

--- a/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifier.scala
+++ b/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifier.scala
@@ -173,7 +173,7 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
       | select age, income from table1 as table2;
       | -- !desc  table2;
       | run table2 as UniqueIdentifier.`` where source="new" and columnName="income1" and mode="inferSchema" and
-      | inputSchema='''{"age":"bigint", "income":"bigint"}''' as uniqueIdentifier;
+      | inputSchema='''[{"col_name":"age", "data_type":"bigint"}]''' as uniqueIdentifier;
       |
       |;
     """.stripMargin)

--- a/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifier.scala
+++ b/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifier.scala
@@ -174,7 +174,6 @@ class SQLUniqueIdentifier(override val uid: String) extends SQLAlg with MllibFun
       | -- !desc  table2;
       | run table2 as UniqueIdentifier.`` where source="new" and columnName="income1" and mode="inferSchema" and
       | inputSchema='''[{"col_name":"age", "data_type":"bigint"}]''' as uniqueIdentifier;
-      |
       |;
     """.stripMargin)
 

--- a/mlsql-mllib/src/test/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifierTest.scala
+++ b/mlsql-mllib/src/test/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifierTest.scala
@@ -1,10 +1,14 @@
 package tech.mlsql.plugins.mllib.ets.fe
 
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.streaming.SparkOperationUtil
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import streaming.core.strategy.platform.SparkRuntime
 import tech.mlsql.test.BasicMLSQLConfig
+
+import java.sql.Timestamp
+import java.time.LocalDateTime
 import java.util.UUID
 
 /**
@@ -29,33 +33,69 @@ class SQLUniqueIdentifierTest extends FlatSpec with SparkOperationUtil with Matc
       // Does not support char type
       var sseq = Seq(
         ("ab_c_1", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa", "a", "aaa1_13", "2022-6-7", "1,2,3,4", 57.12, "  A B  ", "15552231521", 433000, 0),
-        ("ab_c_2", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa","a", "a@qe#", "2022-6-7", "1,2,3,4", 67.12, "  A B  ", "15552231521", 1200, 0),
+        ("ab_c_2", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa", "a", "a@qe#", "2022-6-7", "1,2,3,4", 67.12, "  A B  ", "15552231521", 1200, 0),
         ("ab_c_3", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa", "a", "c_dsar@", "2022-6-7", "1,2,3,4", 57.12, "  A B  ", "15552231521", 89000, 0),
         ("ab_c_4", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa", "a", "ne&ew", "2022-6-7", "1,2,3,4", 25.12, "  A B  ", "15552231521", 36000, 1),
         ("ab_c_5", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa", "a", "e", "2022-6-7", "1,2,3,4", 31.12, "  A B  ", "15552231521", 300000, 1),
         ("ab_c_6", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa/asdfa", "a", "def$$$ewe", "2022-6-7", "1,2,3,4", 23.12, "  A B  ", "15552231521", 238000, 1)
       )
-      val seq_df = spark.createDataFrame(sseq).toDF("name","ctime","harbor_url", "convert_char","convert_char1", "convert_date","rbt","age", "replace_sp","phone", "income", "label")
+      val seq_df = spark.createDataFrame(sseq).toDF("name", "ctime", "harbor_url", "convert_char", "convert_char1", "convert_date", "rbt", "age", "replace_sp", "phone", "income", "label")
       seq_df.show()
       val seq_df1 = seq_df.select(col("*"))
-      val res = et.train(seq_df1, "", Map("source" -> "new", "columnName"->"id"))
+      val res = et.train(seq_df1, "", Map("source" -> "new", "columnName" -> "id"))
       res.show()
 
       val r0 = res.collectAsList().get(0).toSeq
       println(r0.mkString(","))
-        assert(r0.mkString(",") === "1,ab_c_1,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,aaa1_13,2022-6-7,1,2,3,4,57.12,  A B  ,15552231521,433000,0")
+      assert(r0.mkString(",") === "1,ab_c_1,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,aaa1_13,2022-6-7,1,2,3,4,57.12,  A B  ,15552231521,433000,0")
       val r1 = res.collectAsList().get(1).toSeq
       println(r1.mkString(","))
-        assert(r1.mkString(",") === "2,ab_c_2,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,a@qe#,2022-6-7,1,2,3,4,67.12,  A B  ,15552231521,1200,0")
+      assert(r1.mkString(",") === "2,ab_c_2,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,a@qe#,2022-6-7,1,2,3,4,67.12,  A B  ,15552231521,1200,0")
       val r2 = res.collectAsList().get(2).toSeq
       println(r2.mkString(","))
-        assert(r2.mkString(",") === "3,ab_c_3,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,c_dsar@,2022-6-7,1,2,3,4,57.12,  A B  ,15552231521,89000,0")
+      assert(r2.mkString(",") === "3,ab_c_3,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,c_dsar@,2022-6-7,1,2,3,4,57.12,  A B  ,15552231521,89000,0")
       val r3 = res.collectAsList().get(3).toSeq
       println(r3.mkString(","))
-        assert(r3.mkString(",") === "4,ab_c_4,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,ne&ew,2022-6-7,1,2,3,4,25.12,  A B  ,15552231521,36000,1")
+      assert(r3.mkString(",") === "4,ab_c_4,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,ne&ew,2022-6-7,1,2,3,4,25.12,  A B  ,15552231521,36000,1")
       val r4 = res.collectAsList().get(4).toSeq
       println(r4.mkString(","))
-        assert(r4.mkString(",") === "5,ab_c_5,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,e,2022-6-7,1,2,3,4,31.12,  A B  ,15552231521,300000,1")
+      assert(r4.mkString(",") === "5,ab_c_5,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,e,2022-6-7,1,2,3,4,31.12,  A B  ,15552231521,300000,1")
     }
   }
+
+  "param of startIndex" should "Returns the column starting at the specified index" in {
+    withBatchContext(setupBatchContext(startParams)) { runtime: SparkRuntime =>
+      implicit val spark = runtime.sparkSession
+      val et = new SQLUniqueIdentifier()
+      val sseq = Seq(
+        ("elena", 57, "433000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0))),
+        ("abe", 50, "433000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0))),
+        ("AA", 10, "432000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0))),
+        ("cc", 40, "", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0))),
+        ("", 30, "434000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0))),
+        ("bb", 21, "533000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0)))
+      )
+      val seq_df = spark.createDataFrame(sseq).toDF("name", "age", "income", "date")
+      seq_df.show()
+      val seq_df1 = seq_df.select(seq_df("income").cast(DoubleType).alias("income1"), col("*"))
+      val res = et.train(seq_df1, "", Map("source" -> "new", "columnName" -> "id", "startIndex" -> "100"))
+      res.show()
+      val r0 = res.collectAsList().get(0).toSeq
+      println(r0.mkString(","))
+      assert(r0.mkString(",") === "100,433000.0,elena,57,433000,2021-03-08 18:00:00.0")
+      val r1 = res.collectAsList().get(1).toSeq
+      println(r1.mkString(","))
+      assert(r1.mkString(",") === "101,433000.0,abe,50,433000,2021-03-08 18:00:00.0")
+      val r2 = res.collectAsList().get(2).toSeq
+      println(r2.mkString(","))
+      assert(r2.mkString(",") === "102,432000.0,AA,10,432000,2021-03-08 18:00:00.0")
+      val r3 = res.collectAsList().get(3).toSeq
+      println(r3.mkString(","))
+      assert(r3.mkString(",") === "103,null,cc,40,,2021-03-08 18:00:00.0")
+      val r4 = res.collectAsList().get(4).toSeq
+      println(r4.mkString(","))
+      assert(r4.mkString(",") === "104,434000.0,,30,434000,2021-03-08 18:00:00.0")
+    }
+  }
+
 }

--- a/mlsql-mllib/src/test/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifierTest.scala
+++ b/mlsql-mllib/src/test/java/tech/mlsql/plugins/mllib/ets/fe/SQLUniqueIdentifierTest.scala
@@ -1,14 +1,10 @@
 package tech.mlsql.plugins.mllib.ets.fe
 
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.streaming.SparkOperationUtil
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import streaming.core.strategy.platform.SparkRuntime
 import tech.mlsql.test.BasicMLSQLConfig
-
-import java.sql.Timestamp
-import java.time.LocalDateTime
 import java.util.UUID
 
 /**
@@ -30,34 +26,36 @@ class SQLUniqueIdentifierTest extends FlatSpec with SparkOperationUtil with Matc
     withBatchContext(setupBatchContext(startParams)) { runtime: SparkRuntime =>
       implicit val spark = runtime.sparkSession
       val et = new SQLUniqueIdentifier()
-      val sseq = Seq(
-        ("elena", 57, "433000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0))),
-        ("abe", 50, "433000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0))),
-        ("AA", 10, "432000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0))),
-        ("cc", 40, "", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0))),
-        ("", 30, "434000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0))),
-        ("bb", 21, "533000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0)))
+      // Does not support char type
+      var sseq = Seq(
+        ("ab_c_1", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa", "a", "aaa1_13", "2022-6-7", "1,2,3,4", 57.12, "  A B  ", "15552231521", 433000, 0),
+        ("ab_c_2", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa","a", "a@qe#", "2022-6-7", "1,2,3,4", 67.12, "  A B  ", "15552231521", 1200, 0),
+        ("ab_c_3", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa", "a", "c_dsar@", "2022-6-7", "1,2,3,4", 57.12, "  A B  ", "15552231521", 89000, 0),
+        ("ab_c_4", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa", "a", "ne&ew", "2022-6-7", "1,2,3,4", 25.12, "  A B  ", "15552231521", 36000, 1),
+        ("ab_c_5", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa.asdfa", "a", "e", "2022-6-7", "1,2,3,4", 31.12, "  A B  ", "15552231521", 300000, 1),
+        ("ab_c_6", "2022-6-7 10:37", "http://lucy.asdfasdf.sadfa/asdfa", "a", "def$$$ewe", "2022-6-7", "1,2,3,4", 23.12, "  A B  ", "15552231521", 238000, 1)
       )
-      val seq_df = spark.createDataFrame(sseq).toDF("name", "age", "income", "date")
+      val seq_df = spark.createDataFrame(sseq).toDF("name","ctime","harbor_url", "convert_char","convert_char1", "convert_date","rbt","age", "replace_sp","phone", "income", "label")
       seq_df.show()
-      val seq_df1 = seq_df.select(seq_df("income").cast(DoubleType).alias("income1"), col("*"))
+      val seq_df1 = seq_df.select(col("*"))
       val res = et.train(seq_df1, "", Map("source" -> "new", "columnName"->"id"))
       res.show()
+
       val r0 = res.collectAsList().get(0).toSeq
       println(r0.mkString(","))
-      assert(r0.mkString(",") === "1,433000.0,elena,57,433000,2021-03-08 18:00:00.0")
+        assert(r0.mkString(",") === "1,ab_c_1,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,aaa1_13,2022-6-7,1,2,3,4,57.12,  A B  ,15552231521,433000,0")
       val r1 = res.collectAsList().get(1).toSeq
       println(r1.mkString(","))
-      assert(r1.mkString(",") === "2,433000.0,abe,50,433000,2021-03-08 18:00:00.0")
+        assert(r1.mkString(",") === "2,ab_c_2,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,a@qe#,2022-6-7,1,2,3,4,67.12,  A B  ,15552231521,1200,0")
       val r2 = res.collectAsList().get(2).toSeq
       println(r2.mkString(","))
-      assert(r2.mkString(",") === "3,432000.0,AA,10,432000,2021-03-08 18:00:00.0")
+        assert(r2.mkString(",") === "3,ab_c_3,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,c_dsar@,2022-6-7,1,2,3,4,57.12,  A B  ,15552231521,89000,0")
       val r3 = res.collectAsList().get(3).toSeq
       println(r3.mkString(","))
-      assert(r3.mkString(",") === "4,null,cc,40,,2021-03-08 18:00:00.0")
+        assert(r3.mkString(",") === "4,ab_c_4,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,ne&ew,2022-6-7,1,2,3,4,25.12,  A B  ,15552231521,36000,1")
       val r4 = res.collectAsList().get(4).toSeq
       println(r4.mkString(","))
-      assert(r4.mkString(",") === "5,434000.0,,30,434000,2021-03-08 18:00:00.0")
+        assert(r4.mkString(",") === "5,ab_c_5,2022-6-7 10:37,http://lucy.asdfasdf.sadfa.asdfa,a,e,2022-6-7,1,2,3,4,31.12,  A B  ,15552231521,300000,1")
     }
   }
 }


### PR DESCRIPTION
1. 添加参数startIndex支持使用时指定index的起始点
          e.g. `startIndex="3"` 表示index从3开始生成递增的值到唯一列上

2. 修复jdbc数据源求唯一列的时候index总是从0开始的bug

3. 支持设置schema执行唯一标识符ET的结果表结构推断（也可以在业务层实现，减少对引擎的调用）
```
-- 3.1 其中inputSchema支持用户设置上游的schema，该操作为静态解析，不会读取dataFrame表table2的表结构
run table2 as UniqueIdentifier.`` where source="new" and columnName="income1" and mode="inferSchema" and
 inputSchema='''[{"col_name":"age", "data_type":"bigint"}]''' as uniqueIdentifier;

-- 3.2 如果需要程序自动生成，可以通过如下方式组合实现：
select * from table1 as table2;
!desc table2;
!lastCommand named table3;
SET schemaVal = `select to_json(collect_set(struct(col_name,data_type))) from table3` where type="sql" and mode="runtime" and scope="session";
run table2 as UniqueIdentifier.`` where source="new" and columnName="income1" and mode="inferSchema" and
 inputSchema='''${schemaVal}''' as uniqueIdentifier;
```

4. 修复替换列时没有替换列对应的类型导致异常