### PR TITLE
Remove duplicate module byzer-extension-tests in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
         <module>mlsql-language-server</module>
         <module>mlsql-ext-ets</module>
         <module>mlsql-cli</module>
-        <module>byzer-extension-tests</module>
         <module>byzer-exception-render</module>
         <module>byzer-yaml-visualization</module>
         <module>byzer-openmldb</module>


### PR DESCRIPTION
## Issue:
Building byzer-extension failed with error:
[ERROR] 'modules.module[22]' specifies duplicate child module byzer-extension-tests @ line 34, column 17

Cause:
![image](https://user-images.githubusercontent.com/12869649/188340041-6abc1595-1fd2-48f5-9c03-10a3de730d58.png)

