### PR TITLE
删除debug日志

### DIFF
--- a/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLDataSummaryV2.scala
+++ b/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLDataSummaryV2.scala
@@ -221,7 +221,7 @@ class SQLDataSummaryV2(override val uid: String) extends SQLAlg with MllibFuncti
             newE = BigDecimal(v).setScale(round_at, BigDecimal.RoundingMode.HALF_UP).toDouble
           }
         } catch {
-          case e: Exception => logInfo(e.toString)
+          case e: Exception => //pass
         }
         newE
       })


### PR DESCRIPTION
debug日志量过大，每一行数据非数字的字符串执行format是都会报错，删除该代码。