### PR TITLE
添加配置以支持hdfs HA

### DIFF
--- a/mlsql-ext-ets/src/main/java/tech/mlsql/plugins/ext/ets/app/ExistsCommand.scala
+++ b/mlsql-ext-ets/src/main/java/tech/mlsql/plugins/ext/ets/app/ExistsCommand.scala
@@ -1,10 +1,12 @@
 package tech.mlsql.plugins.ext.ets.app
 
 import org.apache.commons.lang3.StringUtils
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.ml.param.Param
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.{DataFrame, SparkSession}
+
 import streaming.dsl.ScriptSQLExec
 import streaming.dsl.auth._
 import streaming.dsl.mmlib.algs.param.BaseParams
@@ -13,7 +15,6 @@ import streaming.dsl.mmlib.{Code, SQLAlg, SQLCode}
 import tech.mlsql.common.form.{Extra, FormParams, Text}
 import tech.mlsql.dsl.auth.ETAuth
 import tech.mlsql.dsl.auth.dsl.mmlib.ETMethod.ETMethod
-import tech.mlsql.tool.HDFSOperatorV2.hadoopConfiguration
 
 /**
  * 14/11/2022 hellozepp(lisheng.zhanglin@163.com)
@@ -88,14 +89,14 @@ class ExistsCommand(override val uid: String) extends SQLAlg with FileCommonFunc
     if (curPath.startsWith("http") || curPath.startsWith("https")) {
       throw new RuntimeException(s"current path can not be supported!")
     }
-
-    rewriteHadoopConfiguration(hadoopConfiguration, params)
+    val conf = new Configuration()
+    rewriteHadoopConfiguration(conf, params)
 
     var fsPath = new Path(curPath)
     var fs: FileSystem = null
     if (params.contains("user") && StringUtils.isNotEmpty(params("user"))) {
       if (curPath.startsWith("/")) {
-        val tmpPath = hadoopConfiguration.get("fs.defaultFS", "file:///")
+        val tmpPath = conf.get("fs.defaultFS", "file:///")
         if (tmpPath.endsWith("/")) {
           curPath = tmpPath.substring(0, tmpPath.length - 1) + curPath
         } else {
@@ -103,9 +104,9 @@ class ExistsCommand(override val uid: String) extends SQLAlg with FileCommonFunc
         }
         fsPath = new Path(curPath)
       }
-      fs = FileSystem.get(fsPath.toUri, hadoopConfiguration, params("user"))
+      fs = FileSystem.get(fsPath.toUri, conf, params("user"))
     } else {
-      fs = fsPath.getFileSystem(hadoopConfiguration)
+      fs = fsPath.getFileSystem(conf)
     }
     val isExists = fs.exists(fsPath)
     session.createDataFrame(session.sparkContext.parallelize(Seq(Tuple1(isExists.toString)), 1)).toDF(

--- a/mlsql-ext-ets/src/main/java/tech/mlsql/plugins/ext/ets/app/FileCommonFunctions.scala
+++ b/mlsql-ext-ets/src/main/java/tech/mlsql/plugins/ext/ets/app/FileCommonFunctions.scala
@@ -1,0 +1,24 @@
+package tech.mlsql.plugins.ext.ets.app
+
+import org.apache.hadoop.conf.Configuration
+
+/**
+ * 20/12/2022 hellozepp(lisheng.zhanglin@163.com)
+ */
+trait FileCommonFunctions {
+
+  def rewriteHadoopConfiguration(hadoopConfiguration: Configuration, config: Map[String, String]): Unit = {
+    config.filter(item => item._1.startsWith("spark.hadoop") || item._1.startsWith("fs."))
+      .foreach { item =>
+        if (item._1.endsWith("fs.defaultFS")) {
+          throw new RuntimeException("fs.defaultFS is not allowed to be modified at runtime! " +
+            "Avoid causing the file system used by the system to be altered.")
+        }
+        if (item._1.startsWith("spark.hadoop")) {
+          hadoopConfiguration.set(item._1.replaceAll("spark.hadoop.", ""), item._2)
+        } else {
+          hadoopConfiguration.set(item._1, item._2)
+        }
+      }
+  }
+}

--- a/mlsql-ext-ets/src/main/java/tech/mlsql/plugins/ext/ets/app/FileStatusCommand.scala
+++ b/mlsql-ext-ets/src/main/java/tech/mlsql/plugins/ext/ets/app/FileStatusCommand.scala
@@ -1,6 +1,7 @@
 package tech.mlsql.plugins.ext.ets.app
 
 import org.apache.commons.lang3.StringUtils
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.spark.ml.param.Param
 import org.apache.spark.sql.expressions.UserDefinedFunction
@@ -16,7 +17,6 @@ import tech.mlsql.common.form.{Extra, FormParams, Text}
 import tech.mlsql.common.utils.path.PathFun
 import tech.mlsql.dsl.auth.ETAuth
 import tech.mlsql.dsl.auth.dsl.mmlib.ETMethod.ETMethod
-import tech.mlsql.tool.HDFSOperatorV2.hadoopConfiguration
 
 /**
  * 14/11/2022 hellozepp(lisheng.zhanglin@163.com)
@@ -88,14 +88,14 @@ class FileStatusCommand(override val uid: String) extends SQLAlg with FileCommon
     if (curPath == null || curPath.isEmpty) {
       return session.emptyDataFrame
     }
-
-    rewriteHadoopConfiguration(hadoopConfiguration, params)
+    val conf = new Configuration()
+    rewriteHadoopConfiguration(conf, params)
 
     var fsPath = new Path(curPath)
     var fs: FileSystem = null
     if (params.contains("user") && StringUtils.isNotEmpty(params("user"))) {
       if (curPath.startsWith("/")) {
-        val tmpPath = hadoopConfiguration.get("fs.defaultFS", "file:///")
+        val tmpPath = conf.get("fs.defaultFS", "file:///")
         if (tmpPath.endsWith("/")) {
           curPath = tmpPath.substring(0, tmpPath.length - 1) + curPath
         } else {
@@ -103,9 +103,9 @@ class FileStatusCommand(override val uid: String) extends SQLAlg with FileCommon
         }
         fsPath = new Path(curPath)
       }
-      fs = FileSystem.get(fsPath.toUri, hadoopConfiguration, params("user"))
+      fs = FileSystem.get(fsPath.toUri, conf, params("user"))
     } else {
-      fs = fsPath.getFileSystem(hadoopConfiguration)
+      fs = fsPath.getFileSystem(conf)
     }
     val fileStatus = fs.getFileStatus(fsPath)
     if (fileStatus == null) {

--- a/mlsql-ext-ets/src/main/java/tech/mlsql/plugins/ext/ets/app/MLSQLETApp.scala
+++ b/mlsql-ext-ets/src/main/java/tech/mlsql/plugins/ext/ets/app/MLSQLETApp.scala
@@ -14,8 +14,10 @@ class MLSQLETApp extends tech.mlsql.app.App with VersionCompatibility with Loggi
     ETRegister.register("AthenaSchemaExt", classOf[AthenaSchemaExt].getName)
     ETRegister.register("LSCommand", classOf[LSCommand].getName)
     ETRegister.register("ExistsCommand", classOf[ExistsCommand].getName)
+    ETRegister.register("FileStatusCommand", classOf[FileStatusCommand].getName)
     CommandCollection.refreshCommandMapping(Map("ls" -> """ run command as LSCommand.`` where path="{0}" """))
     CommandCollection.refreshCommandMapping(Map("exists" -> """ run command as ExistsCommand.`` where path="{0}" """))
+    CommandCollection.refreshCommandMapping(Map("fileStatus" -> """ run command as FileStatusCommand.`` where path="{0}" """))
   }
 
 


### PR DESCRIPTION
示例：
## show命令
```
run command as ExistsCommand.`` where path="hdfs://nameservice1/csv"
and `spark.hadoop.dfs.nameservices`="nameservice1"
and `spark.hadoop.dfs.ha.namenodes.nameservice1`="namenode1"
and `spark.hadoop.dfs.namenode.rpc-address.nameservice1.namenode1`="hadoop3:8020"
and `spark.hadoop.dfs.client.failover.proxy.provider.nameservice1`="org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
as table1;  
select * from table1 as output;
```

## ls命令
```
run command as LSCommand.`` where path="hdfs://nameservice1/csv"
and `spark.hadoop.dfs.nameservices`="nameservice1"
and `spark.hadoop.dfs.ha.namenodes.nameservice1`="namenode1"
and `spark.hadoop.dfs.namenode.rpc-address.nameservice1.namenode1`="hadoop3:8020"
and `spark.hadoop.dfs.client.failover.proxy.provider.nameservice1`="org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
as table1;  
select * from table1 as output;
```