### PR TITLE
数据集剖析指标添加行总数

### DIFF
--- a/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLDataSummaryV2.scala
+++ b/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLDataSummaryV2.scala
@@ -1,5 +1,7 @@
 package tech.mlsql.plugins.mllib.ets.fe
 
+import java.util.Date
+
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
@@ -13,7 +15,6 @@ import tech.mlsql.common.utils.log.Logging
 import tech.mlsql.dsl.auth.ETAuth
 import tech.mlsql.dsl.auth.dsl.mmlib.ETMethod.ETMethod
 
-import java.util.Date
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -185,7 +186,7 @@ class SQLDataSummaryV2(override val uid: String) extends SQLAlg with MllibFuncti
             e = el._1.toString
           }
           val intTypeList = Array("primaryKeyCandidate", "ordinalPosition", "dataLength", "maximumLength",
-            "minimumLength", "nonNullCount", "categoryCount")
+            "minimumLength", "nonNullCount", "categoryCount", "totalCount")
           // 'Max' and 'Min' are required to preserve decimal places, even though the value may be a string, because
           // the decimal type appears as a long-tailed decimal
           val nonFormat = Array("columnName", "dataType")
@@ -247,7 +248,7 @@ class SQLDataSummaryV2(override val uid: String) extends SQLAlg with MllibFuncti
     val selectedMetrics = mutable.HashSet[String]()
     selectedMetrics ++= metrics
     ("%25,median,%75,blankValueRatio,dataLength,dataType,max,maximumLength,mean,min,minimumLength," +
-      "nonNullCount,nullValueRatio,skewness,standardDeviation,standardError,uniqueValueRatio,categoryCount,primaryKeyCandidate,mode"
+      "nonNullCount,nullValueRatio,skewness,totalCount,standardDeviation,standardError,uniqueValueRatio,categoryCount,primaryKeyCandidate,mode"
       ).split(",")
       .filter(selectedMetrics.contains)
   }
@@ -359,11 +360,17 @@ class SQLDataSummaryV2(override val uid: String) extends SQLAlg with MllibFuncti
     }.toArray
   }
 
+  def getTotalCount(schema: StructType, total: Long): Array[Column] = {
+    schema.map {
+      sc => lit(total).alias(sc.name + "_totalCount")
+    }.toArray
+  }
+
   def train(df: DataFrame, path: String, params: Map[String, String]): DataFrame = {
     val round_at = Integer.valueOf(params.getOrElse("roundAt", "2"))
     val selectedMetrics = params.getOrElse(DataSummary.metrics, "dataType,dataLength,max,min,maximumLength,minimumLength," +
       "mean,standardDeviation,standardError,nullValueRatio,blankValueRatio,nonNullCount,uniqueValueRatio," +
-      "primaryKeyCandidate,median,mode").split(",").filter(!_.equals(""))
+      "primaryKeyCandidate,median,mode,totalCount").split(",").filter(!_.equals(""))
     var relativeError = params.getOrElse("relativeError", "0.01").toDouble
     var approxCountDistinct = params.getOrElse("approxCountDistinct", "true").toBoolean
 
@@ -377,8 +384,8 @@ class SQLDataSummaryV2(override val uid: String) extends SQLAlg with MllibFuncti
       smallDatasetAccurately = false
     }
 
+    total = df.count()
     if (smallDatasetAccurately) {
-      total = df.count()
       logInfo(format(s"The whole dataset is [${total}] and the approxThreshold is ${approxThreshold}"))
       if (total == 0) {
         return df.sparkSession.emptyDataFrame
@@ -429,7 +436,8 @@ class SQLDataSummaryV2(override val uid: String) extends SQLAlg with MllibFuncti
       "blankValueRatio" -> emptyCount(schema),
       "nonNullCount" -> countNonNullValue(schema),
       "dataType" -> getDataType(schema),
-      "skewness" -> getSkewness(schema)
+      "skewness" -> getSkewness(schema),
+      "totalCount" -> getTotalCount(schema, total)
     )
     val processedSelectedMetrics = processSelectedMetrics(selectedMetrics)
     var newCols = processedSelectedMetrics.map(name => default_metrics.getOrElse(name, null)).filter(_ != null).flatten

--- a/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLDataSummaryV2.scala
+++ b/mlsql-mllib/src/main/java/tech/mlsql/plugins/mllib/ets/fe/SQLDataSummaryV2.scala
@@ -384,7 +384,10 @@ class SQLDataSummaryV2(override val uid: String) extends SQLAlg with MllibFuncti
       smallDatasetAccurately = false
     }
 
-    total = df.count()
+    if (selectedMetrics.contains("totalCount") || smallDatasetAccurately) {
+      total = df.count()
+    }
+
     if (smallDatasetAccurately) {
       logInfo(format(s"The whole dataset is [${total}] and the approxThreshold is ${approxThreshold}"))
       if (total == 0) {

--- a/mlsql-mllib/src/test/java/tech/mlsql/plugins/mllib/ets/fe/SQLDataSummaryV2Test.scala
+++ b/mlsql-mllib/src/test/java/tech/mlsql/plugins/mllib/ets/fe/SQLDataSummaryV2Test.scala
@@ -21,7 +21,7 @@ import java.util.{Date, UUID}
  */
 class SQLDataSummaryV2Test extends AnyFunSuite with SparkOperationUtil with BasicMLSQLConfig with BeforeAndAfterAll {
   val allMetrics: String = "columnName,ordinalPosition,%25,%75,blankValueRatio,dataLength,dataType,max,maximumLength,mean,median,min,minimumLength," +
-    "nonNullCount,nullValueRatio,skewness,standardDeviation,standardError,uniqueValueRatio,categoryCount,primaryKeyCandidate,mode"
+    "nonNullCount,nullValueRatio,skewness,totalCount,standardDeviation,standardError,uniqueValueRatio,categoryCount,primaryKeyCandidate,mode"
 
 
   def startParams = Array(
@@ -81,10 +81,10 @@ class SQLDataSummaryV2Test extends AnyFunSuite with SparkOperationUtil with Basi
       println(res1DF.collect()(1).mkString(","))
       println(res1DF.collect()(2).mkString(","))
       println(res1DF.collect()(3).mkString(","))
-      assert(res1DF.collect()(0).mkString(",") === "name,1,,,,0.1667,5,string,elena,5,,AA,0,5,0.0,,,,1.0,5,1,")
-      assert(res1DF.collect()(1).mkString(",") === "age,2,23.25,35.0,47.5,0.0,4,integer,57.0,,34.67,10.0,,6,0.0,-0.11,17.77,7.26,1.0,0,1,")
-      assert(res1DF.collect()(2).mkString(",") === "income,3,,,,0.0,6,string,533000.0,6,,432000.0,6,6,0.0,,,,0.6667,4,0,433000.0")
-      assert(res1DF.collect()(3).mkString(",") === "date,4,,,,0.0,8,timestamp,2021-03-08 18:00:00,,,2021-03-08 18:00:00,,6,0.0,,,,0.1667,1,0,2021-03-08 18:00:00")
+      assert(res1DF.collect()(0).mkString(",") === "name,1,,,,0.1667,5,string,elena,5,,AA,0,5,0.0,,6,,,1.0,5,1,")
+      assert(res1DF.collect()(1).mkString(",") === "age,2,23.25,35.0,47.5,0.0,4,integer,57.0,,34.67,10.0,,6,0.0,-0.11,6,17.77,7.26,1.0,0,1,")
+      assert(res1DF.collect()(2).mkString(",") === "income,3,,,,0.0,6,string,533000.0,6,,432000.0,6,6,0.0,,6,,,0.6667,4,0,433000.0")
+      assert(res1DF.collect()(3).mkString(",") === "date,4,,,,0.0,8,timestamp,2021-03-08 18:00:00,,,2021-03-08 18:00:00,,6,0.0,,6,,,0.1667,1,0,2021-03-08 18:00:00")
 
       val sseq = Seq(
         ("elena", 57, 57, 110L, "433000", Timestamp.valueOf(LocalDateTime.of(2021, 3, 8, 18, 0)), 110F, true, null, null, BigDecimal.valueOf(12), 1.123D),
@@ -109,18 +109,18 @@ class SQLDataSummaryV2Test extends AnyFunSuite with SparkOperationUtil with Basi
       println(res2DF.collect()(9).mkString(","))
       println(res2DF.collect()(10).mkString(","))
       println(res2DF.collect()(11).mkString(","))
-      assert(res2DF.collect()(0).mkString(",") === "name,1,,,,0.1667,5,string,elena,5,,AA,0,5,0.0,,,,1.0,5,1,")
-      assert(res2DF.collect()(1).mkString(",") === "favoriteNumber,2,14.25,57.0,57.0,0.0,4,integer,57.0,,37.83,-1.0,,6,0.0,-0.71,29.69,12.12,0.5,0,0,57.0")
-      assert(res2DF.collect()(2).mkString(",") === "age,3,23.25,35.0,47.5,0.0,4,integer,57.0,,34.67,10.0,,6,0.0,-0.11,17.77,7.26,1.0,0,1,")
-      assert(res2DF.collect()(3).mkString(",") === "mock_col1,4,112.5,125.0,145.0,0.0,8,long,160.0,,128.33,100.0,,6,0.0,0.22,23.17,9.46,1.0,0,1,")
-      assert(res2DF.collect()(4).mkString(",") === "income,5,,,,0.1667,6,string,533000.0,6,,432000.0,0,5,0.0,,,,0.8,4,0,433000.0")
-      assert(res2DF.collect()(5).mkString(",") === "date,6,,,,0.0,8,timestamp,2021-03-08 18:00:00,,,2021-03-08 18:00:00,,6,0.0,,,,0.1667,1,0,2021-03-08 18:00:00")
-      assert(res2DF.collect()(6).mkString(",") === "mock_col2,7,117.5,125.0,135.0,0.0,4,float,150.0,,127.5,110.0,,4,0.3333,0.43,17.08,8.54,1.0,0,1,")
-      assert(res2DF.collect()(7).mkString(",") === "alived,8,,,,0.0,1,boolean,true,,,false,,6,0.0,,,,0.3333,2,0,true")
-      assert(res2DF.collect()(8).mkString(",") === "extra,9,,,,0.0,,void,,,,,,0,1.0,,,,0.0,0,0,")
-      assert(res2DF.collect()(9).mkString(",") === "extra1,10,,,,0.0,,void,,,,,,0,1.0,,,,0.0,0,0,")
-      assert(res2DF.collect()(10).mkString(",") === "extra2,11,2.0,2.0,2.0,0.0,16,decimal(38,18),12.0,,3.67,2.0,,6,0.0,1.79,4.08,1.67,0.3333,0,0,2.0")
-      assert(res2DF.collect()(11).mkString(",") === "extra3,12,1.34,2.11,3.09,0.0,8,double,3.38,,2.2,1.12,,6,0.0,0.15,1.01,0.41,0.6667,0,0,")
+      assert(res2DF.collect()(0).mkString(",") === "name,1,,,,0.1667,5,string,elena,5,,AA,0,5,0.0,,6,,,1.0,5,1,")
+      assert(res2DF.collect()(1).mkString(",") === "favoriteNumber,2,14.25,57.0,57.0,0.0,4,integer,57.0,,37.83,-1.0,,6,0.0,-0.71,6,29.69,12.12,0.5,0,0,57.0")
+      assert(res2DF.collect()(2).mkString(",") === "age,3,23.25,35.0,47.5,0.0,4,integer,57.0,,34.67,10.0,,6,0.0,-0.11,6,17.77,7.26,1.0,0,1,")
+      assert(res2DF.collect()(3).mkString(",") === "mock_col1,4,112.5,125.0,145.0,0.0,8,long,160.0,,128.33,100.0,,6,0.0,0.22,6,23.17,9.46,1.0,0,1,")
+      assert(res2DF.collect()(4).mkString(",") === "income,5,,,,0.1667,6,string,533000.0,6,,432000.0,0,5,0.0,,6,,,0.8,4,0,433000.0")
+      assert(res2DF.collect()(5).mkString(",") === "date,6,,,,0.0,8,timestamp,2021-03-08 18:00:00,,,2021-03-08 18:00:00,,6,0.0,,6,,,0.1667,1,0,2021-03-08 18:00:00")
+      assert(res2DF.collect()(6).mkString(",") === "mock_col2,7,117.5,125.0,135.0,0.0,4,float,150.0,,127.5,110.0,,4,0.3333,0.43,6,17.08,8.54,1.0,0,1,")
+      assert(res2DF.collect()(7).mkString(",") === "alived,8,,,,0.0,1,boolean,true,,,false,,6,0.0,,6,,,0.3333,2,0,true")
+      assert(res2DF.collect()(8).mkString(",") === "extra,9,,,,0.0,,void,,,,,,0,1.0,,6,,,0.0,0,0,")
+      assert(res2DF.collect()(9).mkString(",") === "extra1,10,,,,0.0,,void,,,,,,0,1.0,,6,,,0.0,0,0,")
+      assert(res2DF.collect()(10).mkString(",") === "extra2,11,2.0,2.0,2.0,0.0,16,decimal(38,18),12.0,,3.67,2.0,,6,0.0,1.79,6,4.08,1.67,0.3333,0,0,2.0")
+      assert(res2DF.collect()(11).mkString(",") === "extra3,12,1.34,2.11,3.09,0.0,8,double,3.38,,2.2,1.12,,6,0.0,0.15,6,1.01,0.41,0.6667,0,0,")
 
       val sseq2: Seq[(Null, Null)] = Seq(
         (null, null),
@@ -134,8 +134,8 @@ class SQLDataSummaryV2Test extends AnyFunSuite with SparkOperationUtil with Basi
       println("-----------res3DF-----------------")
       println(res3DF.collect()(0).mkString(","))
       println(res3DF.collect()(1).mkString(","))
-      assert(res3DF.collect()(0).mkString(",") === "col1,1,,,,0.0,,void,,,,,,0,1.0,,,,0.0,0,0,")
-      assert(res3DF.collect()(1).mkString(",") === "col2,2,,,,0.0,,void,,,,,,0,1.0,,,,0.0,0,0,")
+      assert(res3DF.collect()(0).mkString(",") === "col1,1,,,,0.0,,void,,,,,,0,1.0,,2,,,0.0,0,0,")
+      assert(res3DF.collect()(1).mkString(",") === "col2,2,,,,0.0,,void,,,,,,0,1.0,,2,,,0.0,0,0,")
 
       val colNames = Array("id", "name", "age", "birth")
       val schema = StructType(colNames.map(fieldName => StructField(fieldName, StringType, nullable = true)))


### PR DESCRIPTION
## 背景
数据集剖析新增一个行总数指标提供给用户查看整体数据的数量大小

## 预期收益
用户可以直观的查看数据集的数量大小

## 变更点
类：SQLDataSummaryV2
方法：dataFormat、processSelectedMetrics、train
新增方法：getTotalCount

## 技术设计
数据集行数代码中本来就有统计，新增数据集总数指标返回

## 兼容性
不存在兼容性问题