### PR TITLE
修改优化byzer-execute-sql部分内容

### DIFF
--- a/byzer-execute-sql/pom.xml
+++ b/byzer-execute-sql/pom.xml
@@ -15,6 +15,11 @@
         <jackson.version>2.10.3</jackson.version>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>1.2.75</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/byzer-execute-sql/src/main/java/tech/mlsql/plugins/execsql/JDBCConn.scala
+++ b/byzer-execute-sql/src/main/java/tech/mlsql/plugins/execsql/JDBCConn.scala
@@ -9,7 +9,7 @@ import streaming.dsl.mmlib.SQLAlg
 import streaming.dsl.mmlib.algs.Functions
 import streaming.dsl.mmlib.algs.param.{BaseParams, WowParams}
 import tech.mlsql.common.utils.serder.json.JSONTool
-import tech.mlsql.ets.Ray
+//import tech.mlsql.ets.Ray
 import tech.mlsql.plugins.execsql
 import tech.mlsql.version.VersionCompatibility
 

--- a/byzer-execute-sql/src/main/java/tech/mlsql/plugins/execsql/JDBCExec.scala
+++ b/byzer-execute-sql/src/main/java/tech/mlsql/plugins/execsql/JDBCExec.scala
@@ -25,7 +25,7 @@ class JDBCExec(override val uid: String) extends SQLAlg with VersionCompatibilit
 
       case List( tableName, "from", sql, "by", connName) =>
         val newDF = ExecSQLApp.executeQueryInDriver(session, connName, sql)
-        newDF.createTempView(tableName)
+        newDF.createOrReplaceTempView(tableName)
       case _ =>
         throw new RuntimeException("!exec_sql connName ''' select * from xxxx ''';")
     }


### PR DESCRIPTION
1.创建临时表修改为创建替换临时表操作
2.更换jsonObject以支持mysql的date数据类型
3.增加会话池找不到name时，抛出异常connection name no found!
4.该byzer-execute-sql，没有单独使用ray，暂时注释掉，保证该ET可以单独被打包。