### PR TITLE
优化会话保持ET和新增读取sas文件ET

### DIFF
--- a/byzer-execute-sql/pom.xml
+++ b/byzer-execute-sql/pom.xml
@@ -21,6 +21,12 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-avro</artifactId>
+            <version>1.12.0</version>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/byzer-execute-sql/src/main/java/tech/mlsql/plugins/execsql/ExecSQLApp.scala
+++ b/byzer-execute-sql/src/main/java/tech/mlsql/plugins/execsql/ExecSQLApp.scala
@@ -1,10 +1,13 @@
 package tech.mlsql.plugins.execsql
 
 
+import streaming.core.strategy.platform.{PlatformManager, SparkRuntime}
 import tech.mlsql.common.utils.log.Logging
 import tech.mlsql.dsl.CommandCollection
 import tech.mlsql.ets.register.ETRegister
+import tech.mlsql.tool.HDFSOperatorV2
 
+import scala.collection.JavaConverters._
 import tech.mlsql.version.VersionCompatibility
 
 
@@ -35,6 +38,12 @@ class ExecSQLApp extends tech.mlsql.app.App with VersionCompatibility with Loggi
 }
 
 object ExecSQLApp extends Logging {
+  def getTmpPath: String = {
+    val runtime = PlatformManager.getRuntime.asInstanceOf[SparkRuntime]
+    val byzerParams = runtime.params.asScala.map(f => (f._1.toString, f._2.toString)).toMap
+    byzerParams.getOrElse("spark.mlsql.execsql.config.tmp.path", HDFSOperatorV2.hadoopConfiguration.get("hadoop.tmp.dir"))
+  }
+
   val versions = Seq(">=2.0.1")
 
 }

--- a/byzer-execute-sql/src/main/java/tech/mlsql/plugins/execsql/JDBCExec.scala
+++ b/byzer-execute-sql/src/main/java/tech/mlsql/plugins/execsql/JDBCExec.scala
@@ -24,7 +24,7 @@ class JDBCExec(override val uid: String) extends SQLAlg with VersionCompatibilit
         JobUtils.executeQueryInDriverWithoutResult(session, connName, sql)
 
       case List( tableName, "from", sql, "by", connName) =>
-        val newDF = JobUtils.executeQueryWithDiskCache(session, connName, sql)
+        val newDF = JobUtils.executeQueryWithDiskCacheParquet(session, connName, sql)
         newDF.createOrReplaceTempView(tableName)
       case _ =>
         throw new RuntimeException("!exec_sql connName ''' select * from xxxx ''';")

--- a/byzer-sas-files/.repo/desc.template.plugin
+++ b/byzer-sas-files/.repo/desc.template.plugin
@@ -1,0 +1,16 @@
+moduleName=byzer-sas-flies-{{spark_binary_version}}
+mainClass=tech.mlsql.plugins.ds.MLSQLSASApp
+scala_version={{scala_binary_version}}
+spark_version={{spark_binary_version}}
+version=0.1.0-SNAPSHOT
+author=lushan
+mlsqlVersions=""
+githubUrl=https://github.com/allwefantasy/mlsql-plugins/tree/master/byzer-openmldb
+mlsqlPluginType=app
+desc=byzer-sas-flies
+
+
+
+
+
+

--- a/byzer-sas-files/.repo/pom.template.xml
+++ b/byzer-sas-files/.repo/pom.template.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>mlsql-plugins-{{spark_binary_version}}_{{scala_binary_version}}</artifactId>
+        <groupId>tech.mlsql</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>byzer-sas-files-{{spark_binary_version}}_{{scala_binary_version}}</artifactId>
+    <properties>
+        <hadoop.version>3.3.2</hadoop.version>
+        <scala.version>2.12.15</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+    </properties>
+    <dependencies>
+
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>spark-package-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <!-- list of other repositories -->
+                <repository>
+                    <id>SparkPackagesRepo</id>
+                    <url>https://repos.spark-packages.org/</url>
+                </repository>
+            </repositories>
+        </profile>
+        <profile>
+            <id>shade</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <relocations>
+
+                            </relocations>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/byzer-sas-files/desc.plugin
+++ b/byzer-sas-files/desc.plugin
@@ -1,0 +1,15 @@
+moduleName=byzer-sas-files-3.3
+mainClass=tech.mlsql.plugins.ds.MLSQLSASApp
+scala_version=2.12
+spark_version=3.3
+version=0.1.0
+author=naopyani
+mlsqlVersions=""
+githubUrl=https://github.com/byzer-org/byzer-extension/tree/master/byzer-sas-files
+mlsqlPluginType=app
+desc=byzer-sas-files
+
+
+
+
+

--- a/byzer-sas-files/pom.xml
+++ b/byzer-sas-files/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>mlsql-plugins-3.3_2.12</artifactId>
+        <groupId>tech.mlsql</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>byzer-sas-files-3.3_2.12</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <properties>
+        <hadoop.version>3.3.2</hadoop.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>saurfang</groupId>
+            <artifactId>spark-sas7bdat</artifactId>
+            <version>3.0.0-s_2.12</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.epam/parso -->
+        <dependency>
+            <groupId>com.epam</groupId>
+            <artifactId>parso</artifactId>
+            <version>2.0.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.17.2</version>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>spark-package-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <!-- list of other repositories -->
+                <repository>
+                    <id>SparkPackagesRepo</id>
+                    <url>https://repos.spark-packages.org/</url>
+                </repository>
+            </repositories>
+        </profile>
+        <profile>
+            <id>shade</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <relocations>
+
+                            </relocations>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/byzer-sas-files/src/main/java/tech/mlsql/plugins/ds/MLSQLSAS.scala
+++ b/byzer-sas-files/src/main/java/tech/mlsql/plugins/ds/MLSQLSAS.scala
@@ -1,0 +1,44 @@
+package tech.mlsql.plugins.ds
+
+import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row}
+import streaming.core.datasource._
+import streaming.dsl.mmlib.algs.param.{BaseParams, WowParams}
+import streaming.dsl.ScriptSQLExec
+
+
+import tech.mlsql.version.VersionCompatibility
+import com.github.saurfang.sas.spark._
+
+
+class MLSQLSAS(override val uid: String) extends MLSQLBaseFileSource with WowParams with VersionCompatibility {
+  def this() = this(BaseParams.randomUID())
+
+  override def load(reader: DataFrameReader, config: DataSourceConfig): DataFrame = {
+    val context = ScriptSQLExec.contextGetOrForTest()
+    val format = config.config.getOrElse("implClass", fullFormat)
+    val owner = config.config.get("owner").getOrElse(context.owner)
+    reader.options(rewriteConfig(config.config)).format(format).load(resourceRealPath(context.execListener, Option(owner), config.path))
+  }
+
+  override def register(): Unit = {
+    DataSourceRegistry.register(MLSQLDataSourceKey(fullFormat, MLSQLSparkDataSourceType), this)
+    DataSourceRegistry.register(MLSQLDataSourceKey(shortFormat, MLSQLSparkDataSourceType), this)
+  }
+
+  override def sourceInfo(config: DataAuthConfig): SourceInfo = {
+    val context = ScriptSQLExec.contextGetOrForTest()
+    val owner = config.config.get("owner").getOrElse(context.owner)
+    SourceInfo(shortFormat, "", resourceRealPath(context.execListener, Option(owner), config.path))
+  }
+
+  override def fullFormat: String = "com.github.saurfang.sas.spark"
+
+  override def shortFormat: String = "sas"
+
+  override def save(writer: DataFrameWriter[Row], config: DataSinkConfig): Any = ???
+
+  override def supportedVersions: Seq[String] = {
+    Seq(">=1.6.0")
+  }
+
+}

--- a/byzer-sas-files/src/main/java/tech/mlsql/plugins/ds/MLSQLSASApp.scala
+++ b/byzer-sas-files/src/main/java/tech/mlsql/plugins/ds/MLSQLSASApp.scala
@@ -1,0 +1,34 @@
+package tech.mlsql.plugins.ds
+
+import streaming.core.datasource.MLSQLRegistry
+import tech.mlsql.common.utils.classloader.ClassLoaderTool
+import tech.mlsql.common.utils.log.Logging
+import tech.mlsql.dsl.CommandCollection
+import tech.mlsql.ets.register.ETRegister
+import tech.mlsql.version.VersionCompatibility
+
+
+/**
+ * 13/11/23 naopyani(naopyani@gmail.com)
+ */
+class MLSQLSASApp extends tech.mlsql.app.App with VersionCompatibility with Logging {
+  override def run(args: Seq[String]): Unit = {
+    val clzz = classOf[MLSQLSAS].getName
+    logInfo(s"Load ds: ${clzz}")
+    val dataSource = ClassLoaderTool.classForName(clzz).newInstance()
+    if (dataSource.isInstanceOf[MLSQLRegistry]) {
+      dataSource.asInstanceOf[MLSQLRegistry].register()
+    }
+  }
+
+  override def supportedVersions: Seq[String] = {
+    MLSQLSASApp.versions
+  }
+
+}
+
+object MLSQLSASApp extends Logging {
+  val versions = Seq(">=2.0.1")
+
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>byzer-expand-include</module>
         <module>byzer-llm</module>
         <module>byzer-execute-sql</module>
+        <module>byzer-sas-files</module>
     </modules>
     <name>MLSQL Plugins</name>
     <url>https://github.com/allwefantasy/mlsql-plugins.git</url>
@@ -343,6 +344,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
1. 新增byzer-sas-files ET 用于是支持sas文件的读取，byzer-lang加载ET"-streaming.plugin.clzznames", "tech.mlsql.plugins.ds.MLSQLSASApp；
2. 会话保持支持缓存路径可配置，byzer-lang启动参数"-spark.mlsql.execsql.config.tmp.path", "/Users/aaa/xxx"。处理逻辑为，当启动参数配置该参数，优先使用该路径；未配置时先查找HDFSOperatorV2.hadoopConfiguration.get("hadoop.tmp.dir")，如没有路径则，最后配置/tmp路径；
3. 缓存文件增加parquet文件类型支持，清理缓存文件一起兼容json和parquet；
4. 缓存文件清理机制优化为周期性触发。